### PR TITLE
Added libtinfo dependency

### DIFF
--- a/display/makefile
+++ b/display/makefile
@@ -1,5 +1,5 @@
 
-LIBS=	-lutility -ldisplay -lpthread -lncurses
+LIBS=	-lutility -ldisplay -lpthread -lncurses -ltinfo
 
 LIBDIRS=	-L../utility -L.
 

--- a/mtop/makefile
+++ b/mtop/makefile
@@ -1,12 +1,12 @@
 
-LIBS=	-lutility -ldisplay -lpthread -lprocps -lncurses
+LIBS=	-lutility -ldisplay -lpthread -lprocps -lncurses -ltinfo
 
-LIBDIRS=	-L../utility -L../display 
+LIBDIRS=	-L../utility -L../display
 
 INCDIRS=	-I../utility -I../display -I../server
 
 # -----------------------
-ALL_TARGETS= mtop 
+ALL_TARGETS= mtop
 include ../makefile.in
 # -----------------------
 


### PR DESCRIPTION
needed to add libtinfo for gcc 4.9.2 on ubuntu 14.04
